### PR TITLE
dyld cache support

### DIFF
--- a/Source/CDFatArch.m
+++ b/Source/CDFatArch.m
@@ -105,7 +105,7 @@
 - (CDMachOFile *)machOFile;
 {
     if (machOFile == nil) {
-        machOFile = [CDFile fileWithData:self.fatFile.data archOffset:fatArch.offset archSize:fatArch.size filename:self.fatFile.filename searchPathState:self.fatFile.searchPathState];
+        machOFile = [CDFile fileWithData:self.fatFile.data archOffset:fatArch.offset archSize:fatArch.size filename:self.fatFile.filename searchPathState:self.fatFile.searchPathState isCache:NO];
     }
 
     return machOFile;

--- a/Source/CDFatFile.m
+++ b/Source/CDFatFile.m
@@ -19,7 +19,7 @@
 
 - (id)initWithData:(NSData *)someData archOffset:(NSUInteger)anOffset archSize:(NSUInteger)aSize filename:(NSString *)aFilename searchPathState:(CDSearchPathState *)aSearchPathState;
 {
-    if ((self = [super initWithData:someData archOffset:anOffset archSize:aSize filename:aFilename searchPathState:aSearchPathState])) {
+    if ((self = [super initWithData:someData archOffset:anOffset archSize:aSize filename:aFilename searchPathState:aSearchPathState isCache:NO])) {
         CDDataCursor *cursor = [[CDDataCursor alloc] initWithData:someData offset:self.archOffset];
 
         struct fat_header header;

--- a/Source/CDFile.h
+++ b/Source/CDFile.h
@@ -26,15 +26,16 @@ extern BOOL CDArchUses64BitABI(CDArch arch);
 
 // Returns CDFatFile or CDMachOFile.
 + (id)fileWithData:(NSData *)someData filename:(NSString *)aFilename searchPathState:(CDSearchPathState *)aSearchPathState;
-+ (id)fileWithData:(NSData *)someData archOffset:(NSUInteger)anOffset archSize:(NSUInteger)aSize filename:(NSString *)aFilename searchPathState:(CDSearchPathState *)aSearchPathState;
++ (id)fileWithData:(NSData *)someData archOffset:(NSUInteger)anOffset archSize:(NSUInteger)aSize filename:(NSString *)aFilename searchPathState:(CDSearchPathState *)aSearchPathState isCache:(BOOL)aIsCache;
 
-- (id)initWithData:(NSData *)someData archOffset:(NSUInteger)anOffset archSize:(NSUInteger)aSize filename:(NSString *)aFilename searchPathState:(CDSearchPathState *)aSearchPathState;
+- (id)initWithData:(NSData *)someData archOffset:(NSUInteger)anOffset archSize:(NSUInteger)aSize filename:(NSString *)aFilename searchPathState:(CDSearchPathState *)aSearchPathState isCache:(BOOL)aIsCache;
 
 @property (readonly) NSString *filename;
 @property (readonly) NSData *data;
 @property (readonly) NSUInteger archOffset;
 @property (readonly) NSUInteger archSize;
 @property (readonly) CDSearchPathState *searchPathState;
+@property (readonly) BOOL isCache;
 
 - (BOOL)bestMatchForLocalArch:(CDArch *)archPtr;
 - (CDMachOFile *)machOFileWithArch:(CDArch)arch;

--- a/Source/CDFile.m
+++ b/Source/CDFile.m
@@ -65,14 +65,15 @@ BOOL CDArchUses64BitABI(CDArch arch)
     NSUInteger archOffset;
     NSUInteger archSize;
     CDSearchPathState *searchPathState;
+    BOOL isCache;
 }
 
 + (id)fileWithData:(NSData *)someData filename:(NSString *)aFilename searchPathState:(CDSearchPathState *)aSearchPathState;
 {
-    return [self fileWithData:someData archOffset:0 archSize:[someData length] filename:aFilename searchPathState:aSearchPathState];
+    return [self fileWithData:someData archOffset:0 archSize:[someData length] filename:aFilename searchPathState:aSearchPathState isCache:NO];
 }
 
-+ (id)fileWithData:(NSData *)someData archOffset:(NSUInteger)anOffset archSize:(NSUInteger)aSize filename:(NSString *)aFilename searchPathState:(CDSearchPathState *)aSearchPathState;
++ (id)fileWithData:(NSData *)someData archOffset:(NSUInteger)anOffset archSize:(NSUInteger)aSize filename:(NSString *)aFilename searchPathState:(CDSearchPathState *)aSearchPathState isCache:(BOOL)aIsCache;
 {
     CDFatFile *aFatFile = nil;
 
@@ -80,7 +81,7 @@ BOOL CDArchUses64BitABI(CDArch arch)
         aFatFile = [[CDFatFile alloc] initWithData:someData archOffset:anOffset archSize:aSize filename:aFilename searchPathState:aSearchPathState];
 
     if (aFatFile == nil) {
-        CDMachOFile *machOFile = [[CDMachOFile alloc] initWithData:someData archOffset:anOffset archSize:aSize filename:aFilename searchPathState:aSearchPathState];
+        CDMachOFile *machOFile = [[CDMachOFile alloc] initWithData:someData archOffset:anOffset archSize:aSize filename:aFilename searchPathState:aSearchPathState isCache:aIsCache];
         return machOFile;
     }
 
@@ -93,7 +94,7 @@ BOOL CDArchUses64BitABI(CDArch arch)
     return nil;
 }
 
-- (id)initWithData:(NSData *)someData archOffset:(NSUInteger)anOffset archSize:(NSUInteger)aSize filename:(NSString *)aFilename searchPathState:(CDSearchPathState *)aSearchPathState;
+- (id)initWithData:(NSData *)someData archOffset:(NSUInteger)anOffset archSize:(NSUInteger)aSize filename:(NSString *)aFilename searchPathState:(CDSearchPathState *)aSearchPathState isCache:(BOOL)aIsCache;
 {
     if ((self = [super init])) {
         // Otherwise reading the magic number fails.
@@ -106,6 +107,7 @@ BOOL CDArchUses64BitABI(CDArch arch)
         archOffset = anOffset;
         archSize = aSize;
         searchPathState = aSearchPathState;
+        isCache = aIsCache;
     }
 
     return self;
@@ -118,6 +120,7 @@ BOOL CDArchUses64BitABI(CDArch arch)
 @synthesize archOffset;
 @synthesize archSize;
 @synthesize searchPathState;
+@synthesize isCache;
 
 - (BOOL)bestMatchForLocalArch:(CDArch *)archPtr;
 {

--- a/Source/CDMachOFile.h
+++ b/Source/CDMachOFile.h
@@ -23,7 +23,7 @@ typedef NSUInteger CDByteOrder;
 
 @interface CDMachOFile : CDFile
 
-- (id)initWithData:(NSData *)someData archOffset:(NSUInteger)anOffset archSize:(NSUInteger)aSize filename:(NSString *)aFilename searchPathState:(CDSearchPathState *)aSearchPathState;
+- (id)initWithData:(NSData *)someData archOffset:(NSUInteger)anOffset archSize:(NSUInteger)aSize filename:(NSString *)aFilename searchPathState:(CDSearchPathState *)aSearchPathState isCache:(BOOL)aIsCache;
 
 - (NSString *)description;
 
@@ -92,6 +92,10 @@ typedef NSUInteger CDByteOrder;
 // Checks compressed dyld info on 10.6 or later.
 - (BOOL)hasRelocationEntryForAddress2:(NSUInteger)address;
 - (NSString *)externalClassNameForAddress2:(NSUInteger)address;
+
+- (BOOL) _loadCacheInfo;
+- (NSUInteger) _cacheAddressForImage:(NSString *)fileName;
+- (NSUInteger) _cacheOffsetForAddress:(NSUInteger)address;
 
 @property (readonly) BOOL hasObjectiveC1Data;
 @property (readonly) BOOL hasObjectiveC2Data;

--- a/class-dump.m
+++ b/class-dump.m
@@ -67,6 +67,7 @@ int main(int argc, char *argv[])
         CDArch targetArch;
         BOOL hasSpecifiedArch = NO;
         NSString *outputPath;
+        NSString *cacheName = nil;
 
         int ch;
         BOOL errorFlag = NO;
@@ -89,6 +90,7 @@ int main(int argc, char *argv[])
             { "sdk-ios",                 required_argument, NULL, CD_OPT_SDK_IOS },
             { "sdk-mac",                 required_argument, NULL, CD_OPT_SDK_MAC },
             { "sdk-root",                required_argument, NULL, CD_OPT_SDK_ROOT },
+            { "cache",                   required_argument, NULL, 'c' },
             { NULL,                      0,                 NULL, 0 },
         };
 
@@ -99,7 +101,7 @@ int main(int argc, char *argv[])
 
         CDClassDump *classDump = [[CDClassDump alloc] init];
 
-        while ( (ch = getopt_long(argc, argv, "aAC:f:HIo:rRsSt", longopts, NULL)) != -1) {
+        while ( (ch = getopt_long(argc, argv, "aAC:f:HIo:rRsStc:", longopts, NULL)) != -1) {
             switch (ch) {
                 case CD_OPT_ARCH: {
                     NSString *name = [NSString stringWithUTF8String:optarg];
@@ -168,6 +170,11 @@ int main(int argc, char *argv[])
                     }
 
                     // Last one wins now.
+                    break;
+                }
+                    
+                case 'c': {
+                    cacheName = [NSString stringWithUTF8String:optarg];
                     break;
                 }
                     
@@ -262,7 +269,14 @@ int main(int argc, char *argv[])
                 }
 
                 classDump.searchPathState.executablePath = [executablePath stringByDeletingLastPathComponent];
-                CDFile *file = [CDFile fileWithData:data filename:executablePath searchPathState:classDump.searchPathState];
+                CDFile *file;
+                
+                if(cacheName) {
+                    file = [CDFile fileWithData:data archOffset:0 archSize:[data length] filename:cacheName searchPathState:classDump.searchPathState isCache:YES];
+                } else {
+                    file = [CDFile fileWithData:data filename:executablePath searchPathState:classDump.searchPathState];
+                }
+                
                 if (file == nil) {
                     fprintf(stderr, "class-dump: Input file (%s) is neither a Mach-O file nor a fat archive.\n", [executablePath UTF8String]);
                     exit(1);


### PR DESCRIPTION
Added support for using class-dump directly against dyld caches.
- This functionality has only been tested against iOS dyld shared caches.
- dyld shared caches from iOS must be retrieved directly from the decrypted firmware.
  Caches from the live device (retrieved through scp, etc.) have a slide applied and
  cannot be used. (The only way I've reliably found to get around this is to read the
  file directly off the raw block device, otherwise the kernel screws with the file like
  a rootkit).
