### PR TITLE
Get class-dump building on Mac OS X 10.8.

### DIFF
--- a/Source/CDLCVersionMinimum.m
+++ b/Source/CDLCVersionMinimum.m
@@ -18,7 +18,12 @@
         versionMinCommand.cmd = [cursor readInt32];
         versionMinCommand.cmdsize = [cursor readInt32];
         versionMinCommand.version = [cursor readInt32];
+#ifdef LC_SOURCE_VERSION /* which is defined only in OS X 10.8 */
+        /* The name of this field is new in OS X 10.8. */
+        versionMinCommand.sdk = [cursor readInt32];
+#else
         versionMinCommand.reserved = [cursor readInt32];
+#endif
     }
 
     return self;


### PR DESCRIPTION
The name of the fourth field in "struct version_min_command" changed between 10.7 and 10.8. I'm not sure how to test which OS version we're using, but someone online suggests looking for LC_SOURCE_VERSION, which is also new in 10.8.

If you (or any watcher) know a better way, something like <pseudocode>OS_X_VERSION >= 1008</pseudocode>, please make the appropriate substitution and I'll merge it back into my fork.
