### PR TITLE
Fix Objective-C 2 ivars offsets

### DIFF
--- a/Source/CDObjectiveC2Processor.m
+++ b/Source/CDObjectiveC2Processor.m
@@ -409,8 +409,10 @@
             if (objc2Ivar.name != 0) {
                 NSString *name = [self.machOFile stringAtAddress:objc2Ivar.name];
                 NSString *type = [self.machOFile stringAtAddress:objc2Ivar.type];
+                CDMachOFileDataCursor *offsetCursor = [[CDMachOFileDataCursor alloc] initWithFile:self.machOFile address:objc2Ivar.offset];
+                NSUInteger offset = [offsetCursor readPtr];
                 
-                CDOCIvar *ivar = [[CDOCIvar alloc] initWithName:name type:type offset:objc2Ivar.offset];
+                CDOCIvar *ivar = [[CDOCIvar alloc] initWithName:name type:type offset:offset];
                 [ivars addObject:ivar];
             } else {
                 //NSLog(@"%016lx %016lx %016lx  %08x %08x", objc2Ivar.offset, objc2Ivar.name, objc2Ivar.type, objc2Ivar.alignment, objc2Ivar.size);


### PR DESCRIPTION
Currently, `class-dump -a` prints the `_OBJC_IVAR_$_*` addresses in the `__DATA,__objc_ivar` section. This is not very useful. With this fix, the default offset is printed instead.

Example from iOS 6 CoreFoundation.

Before the fix:

``` objective-c
@interface NSCache : NSObject
{
    id _delegate;   // 1828480 = 0x1be680
    void *_private[5];  // 1828476 = 0x1be67c
    void *_reserved;    // 1828484 = 0x1be684
}
```

After the fix:

``` objective-c
@interface NSCache : NSObject
{
    id _delegate;   // 4 = 0x4
    void *_private[5];  // 8 = 0x8
    void *_reserved;    // 28 = 0x1c
}
```
