### PR TITLE
Adding handling for @loader_path to class-dump

### DIFF
--- a/Source/CDClassDump.m
+++ b/Source/CDClassDump.m
@@ -190,10 +190,13 @@ NSString *CDErrorKey_Exception    = @"CDErrorKey_Exception";
 {
     NSString *adjustedName = nil;
     NSString *executablePathPrefix = @"@executable_path";
+    NSString *loaderPathPrefix = @"@loader_path";
     NSString *rpathPrefix = @"@rpath";
 
     if ([name hasPrefix:executablePathPrefix]) {
         adjustedName = [name stringByReplacingOccurrencesOfString:executablePathPrefix withString:self.searchPathState.executablePath];
+    } else if ([name hasPrefix:loaderPathPrefix]) {
+        adjustedName = [name stringByReplacingOccurrencesOfString:loaderPathPrefix withString:self.searchPathState.executablePath];
     } else if ([name hasPrefix:rpathPrefix]) {
         //NSLog(@"Searching for %@ through run paths: %@", anID, [searchPathState searchPaths]);
         for (NSString *searchPath in [self.searchPathState searchPaths]) {


### PR DESCRIPTION
When asked to recursively expand frameworks (-r), class-dump doesn't seem to have handling for @loader_path:

```
class-dump[2305:707] Warning: Failed to load: @loader_path/../Frameworks/SomeFramework.framework/Versions/A/SomeFramework
```

According to [this](https://wincent.com/wiki/@executable_path,_@load_path_and_@rpath), @loader_path is intended to be used to locate libraries relative to dynamically loaded plugins. It can end up being evaluated as @executable_path if that's what is actually doing the loading of the library.

The change I made in my pull request simply treats the @loader_path as though it were @executable_path. If there's some extra special handling that would need to be implemented for proper handling of @loader_path, I would have to yield to those wiser in the ways of mach-o library loading. 
