### PR TITLE
Very basic blocks support

### DIFF
--- a/Source/CDType.h
+++ b/Source/CDType.h
@@ -10,6 +10,7 @@
 - (id)init;
 - (id)initSimpleType:(int)type;
 - (id)initIDType:(CDTypeName *)name;
+- (id)initBlockType;
 - (id)initIDTypeWithProtocols:(NSArray *)protocols;
 - (id)initStructType:(CDTypeName *)name members:(NSArray *)members;
 - (id)initUnionType:(CDTypeName *)name members:(NSArray *)members;
@@ -22,6 +23,7 @@
 
 @property (nonatomic, readonly) int primitiveType;
 @property (nonatomic, readonly) BOOL isIDType;
+@property (nonatomic, readonly) BOOL isBlockType;
 @property (nonatomic, readonly) BOOL isNamedObject;
 @property (nonatomic, readonly) BOOL isTemplateType;
 

--- a/Source/CDType.m
+++ b/Source/CDType.m
@@ -121,6 +121,11 @@ static BOOL debugMerge = NO;
     return self;
 }
 
+- (id)initBlockType;
+{
+    return [self initModifier:'@' type:[[CDType alloc] initSimpleType:'?']];
+}
+
 - (id)initIDTypeWithProtocols:(NSArray *)protocols;
 {
     if ((self = [self init])) {
@@ -244,6 +249,11 @@ static BOOL debugMerge = NO;
     return self.primitiveType == '@' && self.typeName == nil;
 }
 
+- (BOOL)isBlockType;
+{
+    return self.isIDType && self.subtype.primitiveType == '?';
+}
+
 - (BOOL)isNamedObject;
 {
     return self.primitiveType == T_NAMED_OBJECT;
@@ -309,7 +319,9 @@ static BOOL debugMerge = NO;
             
         case '@':
             if (currentName == nil) {
-                if (_protocols == nil)
+                if (_subtype.primitiveType == '?')
+                    result = @"CDUnknownBlockType";
+                else if (_protocols == nil)
                     result = @"id";
                 else
                     result = [NSString stringWithFormat:@"id <%@>", [_protocols componentsJoinedByString:@", "]];
@@ -822,6 +834,8 @@ static BOOL debugMerge = NO;
 
     if ((self.primitiveType == '{' || self.primitiveType == '(') && [self.members count] > 0) {
         [typeController phase0RegisterStructure:self usedInMethod:isUsedInMethod];
+    } else if (self.isBlockType) {
+        typeController.hasBlocks = YES;
     }
 }
 

--- a/Source/CDTypeController.h
+++ b/Source/CDTypeController.h
@@ -22,6 +22,8 @@
 @property (nonatomic, readonly) BOOL shouldShowMethodAddresses;
 @property (nonatomic, readonly) BOOL targetArchUses64BitABI;
 
+@property (nonatomic, assign) BOOL hasBlocks;
+
 - (CDType *)typeFormatter:(CDTypeFormatter *)typeFormatter replacementForType:(CDType *)type;
 - (NSString *)typeFormatter:(CDTypeFormatter *)typeFormatter typedefNameForStructure:(CDType *)structureType level:(NSUInteger)level;
 - (void)typeFormatter:(CDTypeFormatter *)typeFormatter didReferenceClassName:(NSString *)name;

--- a/Source/CDTypeController.m
+++ b/Source/CDTypeController.m
@@ -142,6 +142,11 @@ static BOOL debug = NO;
 
     [self.unionTable appendNamedStructuresToString:resultString formatter:self.structDeclarationTypeFormatter markName:@"Named Unions"];
     [self.unionTable appendTypedefsToString:resultString        formatter:self.structDeclarationTypeFormatter markName:@"Typedef'd Unions"];
+    
+    if (self.hasBlocks) {
+        [resultString appendString:@"#pragma mark Blocks\n\n"];
+        [resultString appendFormat:@"typedef void (^CDUnknownBlockType)(void); // return type and parameters are unknown\n\n"];
+    }
 }
 
 // Call this before calling generateMemberNames.

--- a/Source/CDTypeParser.m
+++ b/Source/CDTypeParser.m
@@ -253,7 +253,12 @@ static NSString *CDTokenDescription(int token)
 
             [self match:TK_QUOTED_STRING];
         } else {
-            result = [[CDType alloc] initIDType:nil];
+            if (_lookahead == '?') {
+                result = [[CDType alloc] initBlockType];
+                [self match:'?'];
+            } else {
+                result = [[CDType alloc] initIDType:nil];
+            }
         }
     } else if (_lookahead == '{') { // structure
         CDTypeLexerState savedState = self.lexer.state;


### PR DESCRIPTION
Before this patch:

``` objective-c
- (void)enumerateObjectsUsingBlock:(id)arg1;
```

After this patch:

``` objective-c
typedef void (^CDUnknownBlockType)(void); // return type and parameters are unknown

- (void)enumerateObjectsUsingBlock:(CDUnknownBlockType)arg1;
```

At least it is clear that the parameter is a block.

I quickly hacked that, maybe there is a better way to do it.
