### PR TITLE
Small fixes to list header entsize

### DIFF
--- a/Source/CDObjectiveC2Processor.m
+++ b/Source/CDObjectiveC2Processor.m
@@ -353,7 +353,8 @@
         
         struct cd_objc2_list_header listHeader;
         
-        listHeader.entsize = [cursor readInt32];
+        // See getEntsize() from http://www.opensource.apple.com/source/objc4/objc4-532.2/runtime/objc-runtime-new.h
+        listHeader.entsize = [cursor readInt32] & ~(uint32_t)3;
         listHeader.count   = [cursor readInt32];
         NSParameterAssert(listHeader.entsize == 3 * [self.machOFile ptrSize]);
         


### PR DESCRIPTION
So that [dyld_decache](https://github.com/kennytm/Miscellaneous/blob/d30f30773e8bfc3a355dcb3a2583974fb08ca5f4/dyld_decache.cpp#L1441-L1444) doesn’t have to workaround.
