### PR TITLE
Use the encryption info for 64-bits goodies available in the 10.9 SDK

### DIFF
--- a/Source/CDLCEncryptionInfo.h
+++ b/Source/CDLCEncryptionInfo.h
@@ -5,10 +5,6 @@
 
 #import "CDLoadCommand.h"
 
-#ifndef LC_ENCRYPTION_INFO_64
-#define LC_ENCRYPTION_INFO_64 0x2C
-#endif
-
 @interface CDLCEncryptionInfo : CDLoadCommand
 
 @property (nonatomic, readonly) uint32_t cryptoff;

--- a/Source/CDLCEncryptionInfo.m
+++ b/Source/CDLCEncryptionInfo.m
@@ -9,9 +9,7 @@
 
 @implementation CDLCEncryptionInfo
 {
-    // TODO: (2013-09-11) Use struct encryption_info_command_64 once it's available in the OS X SDK.
-    struct encryption_info_command _encryptionInfoCommand;
-    uint32_t _pad;
+    struct encryption_info_command_64 _encryptionInfoCommand;
 }
 
 - (id)initWithDataCursor:(CDMachOFileDataCursor *)cursor;
@@ -24,7 +22,7 @@
         _encryptionInfoCommand.cryptsize = [cursor readInt32];
         _encryptionInfoCommand.cryptid   = [cursor readInt32];
         if (_encryptionInfoCommand.cmd == LC_ENCRYPTION_INFO_64) {
-            _pad = [cursor readInt32];
+            _encryptionInfoCommand.pad = [cursor readInt32];
         }
     }
 


### PR DESCRIPTION
Use stuff available in the SDK rather than redefining it.
