### PR TITLE
Fix invalid section offsets

### DIFF
--- a/Source/CDSection.m
+++ b/Source/CDSection.m
@@ -29,6 +29,11 @@
         _section.addr      = [cursor readPtr];
         _section.size      = [cursor readPtr];
         _section.offset    = [cursor readInt32];
+        uint32_t dyldOffset = (uint32_t)(_section.addr - segment.vmaddr + segment.fileoff);
+        if (_section.offset > 0 && _section.offset != dyldOffset) {
+            fprintf(stderr, "Warning: Invalid section offset 0x%08x replaced with 0x%08x in %s,%s\n", _section.offset, dyldOffset, [_segmentName UTF8String], [_sectionName UTF8String]);
+            _section.offset = dyldOffset;
+        }
         _section.align     = [cursor readInt32];
         _section.reloff    = [cursor readInt32];
         _section.nreloc    = [cursor readInt32];


### PR DESCRIPTION
[Hopper v3](http://www.hopperapp.com) has invalid section offsets in order to trick reverse engineering tools such as class-dump. Since dyld doesn’t actually read those section offsets when loading binaries, it’s safe to compute them and fix them.
