### PR TITLE
Add support for non-lazy classes and categories

### DIFF
--- a/Source/CDOCProtocol.m
+++ b/Source/CDOCProtocol.m
@@ -50,6 +50,16 @@
     return self;
 }
 
+- (BOOL)isEqual:(id)object;
+{
+    return [object isKindOfClass:[CDOCProtocol class]] && [self.sortableName isEqualToString:((CDOCProtocol *)object).sortableName];
+}
+
+- (NSUInteger)hash;
+{
+    return [self.sortableName hash];
+}
+
 #pragma mark - Debugging
 
 - (NSString *)description;

--- a/Source/CDObjectiveC2Processor.m
+++ b/Source/CDObjectiveC2Processor.m
@@ -36,26 +36,30 @@
 
 - (void)loadClasses;
 {
-    CDSection *section = [[self.machOFile segmentWithName:@"__DATA"] sectionWithName:@"__objc_classlist"];
-    
-    CDMachOFileDataCursor *cursor = [[CDMachOFileDataCursor alloc] initWithSection:section];
-    while ([cursor isAtEnd] == NO) {
-        uint64_t val = [cursor readPtr];
-        CDOCClass *aClass = [self loadClassAtAddress:val];
-        if (aClass != nil) {
-            [self addClass:aClass withAddress:val];
+    for (NSString *sectionName in @[@"__objc_classlist", @"__objc_nlclslist"]) {
+        CDSection *section = [[self.machOFile segmentWithName:@"__DATA"] sectionWithName:sectionName];
+        
+        CDMachOFileDataCursor *cursor = [[CDMachOFileDataCursor alloc] initWithSection:section];
+        while ([cursor isAtEnd] == NO) {
+            uint64_t val = [cursor readPtr];
+            CDOCClass *aClass = [self loadClassAtAddress:val];
+            if (aClass != nil) {
+                [self addClass:aClass withAddress:val];
+            }
         }
     }
 }
 
 - (void)loadCategories;
 {
-    CDSection *section = [[self.machOFile segmentWithName:@"__DATA"] sectionWithName:@"__objc_catlist"];
-    
-    CDMachOFileDataCursor *cursor = [[CDMachOFileDataCursor alloc] initWithSection:section];
-    while ([cursor isAtEnd] == NO) {
-        CDOCCategory *category = [self loadCategoryAtAddress:[cursor readPtr]];
-        [self addCategory:category];
+    for (NSString *sectionName in @[@"__objc_catlist", @"__objc_nlcatlist"]) {
+        CDSection *section = [[self.machOFile segmentWithName:@"__DATA"] sectionWithName:sectionName];
+        
+        CDMachOFileDataCursor *cursor = [[CDMachOFileDataCursor alloc] initWithSection:section];
+        while ([cursor isAtEnd] == NO) {
+            CDOCCategory *category = [self loadCategoryAtAddress:[cursor readPtr]];
+            [self addCategory:category];
+        }
     }
 }
 

--- a/Source/CDObjectiveCProcessor.m
+++ b/Source/CDObjectiveCProcessor.m
@@ -24,10 +24,10 @@
 {
     CDMachOFile *_machOFile;
     
-    NSMutableArray *_classes;
+    NSMutableOrderedSet *_classes;
     NSMutableDictionary *_classesByAddress;
     
-    NSMutableArray *_categories;
+    NSMutableOrderedSet *_categories;
     
     CDProtocolUniquer *_protocolUniquer;
 }
@@ -36,9 +36,9 @@
 {
     if ((self = [super init])) {
         _machOFile = machOFile;
-        _classes = [[NSMutableArray alloc] init];
+        _classes = [[NSMutableOrderedSet alloc] init];
         _classesByAddress = [[NSMutableDictionary alloc] init];
-        _categories = [[NSMutableArray alloc] init];
+        _categories = [[NSMutableOrderedSet alloc] init];
         
         _protocolUniquer = [[CDProtocolUniquer alloc] init];
     }
@@ -177,8 +177,8 @@
 - (void)recursivelyVisit:(CDVisitor *)visitor;
 {
     NSMutableArray *classesAndCategories = [[NSMutableArray alloc] init];
-    [classesAndCategories addObjectsFromArray:_classes];
-    [classesAndCategories addObjectsFromArray:_categories];
+    [classesAndCategories addObjectsFromArray:[_classes array]];
+    [classesAndCategories addObjectsFromArray:[_categories array]];
 
     [visitor willVisitObjectiveCProcessor:self];
     [visitor visitObjectiveCProcessor:self];


### PR DESCRIPTION
An alternative to #45 using `NSMutableOrderedSet` to avoid duplicates. Also, it doesn’t add an `uint64_t address` property on `CDOCCategory` and `CDOCClass`.
