### PR TITLE
Be able to compile with class-dump headers

### DIFF
--- a/Source/CDTextClassDumpVisitor.m
+++ b/Source/CDTextClassDumpVisitor.m
@@ -124,6 +124,12 @@ static BOOL debug = NO;
     CDOCProperty *property = [propertyState propertyForAccessor:method.name];
     if (property == nil) {
         //NSLog(@"No property for method: %@", method.name);
+        // C++ destructors can't be called and this header can't be compiled with one declared. So let's comment it out.
+        // Leave it there so the user knows that the class has a C++ implementation though.
+        if ([method.name isEqualToString:@".cxx_destruct"]) {
+            [self.resultString appendString:@"// "];
+        }
+
         [self.resultString appendString:@"- "];
         [method appendToString:self.resultString typeController:self.classDump.typeController];
         [self.resultString appendString:@"\n"];

--- a/Source/CDTextClassDumpVisitor.m
+++ b/Source/CDTextClassDumpVisitor.m
@@ -6,6 +6,7 @@
 #import "CDTextClassDumpVisitor.h"
 
 #import "CDClassDump.h"
+#import "CDType.h"
 #import "CDOCClass.h"
 #import "CDOCCategory.h"
 #import "CDOCMethod.h"
@@ -122,7 +123,9 @@ static BOOL debug = NO;
 - (void)visitInstanceMethod:(CDOCMethod *)method propertyState:(CDVisitorPropertyState *)propertyState;
 {
     CDOCProperty *property = [propertyState propertyForAccessor:method.name];
-    if (property == nil) {
+    if (property.isReadOnly && [property.setter isEqualToString:method.name]) {
+        [self.resultString appendFormat:@"- (void)%@(%@)arg1;\n", method.name, [property.type formattedString:nil formatter:self.classDump.typeController.propertyTypeFormatter level:0]];
+    } else if (property == nil) {
         //NSLog(@"No property for method: %@", method.name);
         // C++ destructors can't be called and this header can't be compiled with one declared. So let's comment it out.
         // Leave it there so the user knows that the class has a C++ implementation though.

--- a/Source/CDType.m
+++ b/Source/CDType.m
@@ -437,6 +437,8 @@ static BOOL debugMerge = NO;
                 result = @"CDUnknownFunctionPointerType";
             else
                 result = [NSString stringWithFormat:@"CDUnknownFunctionPointerType %@", currentName];
+            result = [NSString stringWithFormat:@"void * /* %@ */", result];
+
             break;
             
         case T_BLOCK_TYPE:
@@ -447,6 +449,7 @@ static BOOL debugMerge = NO;
                     result = @"CDUnknownBlockType";
                 else
                     result = [NSString stringWithFormat:@"CDUnknownBlockType %@", currentName];
+                result = [NSString stringWithFormat:@"id /* %@ */", result];
             }
             break;
             

--- a/Source/CDVisitorPropertyState.m
+++ b/Source/CDVisitorPropertyState.m
@@ -28,7 +28,7 @@
             //NSLog(@"property: %@, getter: %@, setter: %@", [property name], [property getter], [property setter]);
             _propertiesByName[property.name] = property;
             _propertiesByAccessor[property.getter] = property;
-            if (property.isReadOnly == NO)
+            if (property.isReadOnly == NO || property.setter)
                 _propertiesByAccessor[property.setter] = property;
         }
     }


### PR DESCRIPTION
This fixes a few problems from trying to compile in with class-dump headers.
Namely:
- CDUnknownBlockType and CDUnknownFunctionPointerType are helpful but the CDTypes.h file is not automatically included and even if it were, it is too specific
- .cxx_destruct methods are included in the header (which cannot be compiled)
- if there is a setter for a read-only property, it is exposed incorrectly