### PR TITLE
Support for C11 _Atomic types

### DIFF
--- a/Source/CDType.m
+++ b/Source/CDType.m
@@ -265,7 +265,7 @@ static BOOL debugMerge = NO;
 
 - (BOOL)isModifierType;
 {
-    return _primitiveType == 'j' || _primitiveType == 'r' || _primitiveType == 'n' || _primitiveType == 'N' || _primitiveType == 'o' || _primitiveType == 'O' || _primitiveType == 'R' || _primitiveType == 'V';
+    return _primitiveType == 'j' || _primitiveType == 'r' || _primitiveType == 'n' || _primitiveType == 'N' || _primitiveType == 'o' || _primitiveType == 'O' || _primitiveType == 'R' || _primitiveType == 'V' || _primitiveType == 'A';
 }
 
 - (int)typeIgnoringModifiers;
@@ -458,6 +458,7 @@ static BOOL debugMerge = NO;
         case 'O':
         case 'R':
         case 'V':
+        case 'A':
             if (_subtype == nil) {
                 if (currentName == nil)
                     result = [self formattedStringForSimpleType];
@@ -528,6 +529,7 @@ static BOOL debugMerge = NO;
         case 'O': return @"bycopy";
         case 'R': return @"byref";
         case 'V': return @"oneway";
+        case 'A': return @"_Atomic";
         default:
             break;
     }
@@ -611,6 +613,7 @@ static BOOL debugMerge = NO;
         case 'O':
         case 'R':
         case 'V':
+        case 'A':
             result = [NSString stringWithFormat:@"%c%@", _primitiveType, [_subtype _typeStringWithVariableNamesToLevel:level showObjectTypes:shouldShowObjectTypes]];
             break;
             

--- a/Source/CDTypeParser.m
+++ b/Source/CDTypeParser.m
@@ -204,7 +204,8 @@ static NSString *CDTokenDescription(int token)
         || _lookahead == 'o'
         || _lookahead == 'O'
         || _lookahead == 'R'
-        || _lookahead == 'V') { // modifiers
+        || _lookahead == 'V'
+        || _lookahead == 'A') { // modifiers
         int modifier = _lookahead;
         [self match:modifier];
 
@@ -460,7 +461,8 @@ static NSString *CDTokenDescription(int token)
         || token == 'o'
         || token == 'O'
         || token == 'R'
-        || token == 'V')
+        || token == 'V'
+        || token == 'A')
         return YES;
 
     return NO;


### PR DESCRIPTION
Ran into [these](http://en.cppreference.com/w/c/language/atomic) in `/System/Library/PrivateFrameworks/Safari.framework`.
