### PR TITLE
support new __DATA_CONST segment in ios 9 binaries

### DIFF
--- a/Source/CDMachOFile.h
+++ b/Source/CDMachOFile.h
@@ -51,6 +51,7 @@ typedef enum : NSUInteger {
 - (NSString *)filetypeDescription;
 - (NSString *)flagDescription;
 
+- (CDLCSegment *)dataConstSegment;
 - (CDLCSegment *)segmentWithName:(NSString *)segmentName;
 - (CDLCSegment *)segmentContainingAddress:(NSUInteger)address;
 - (NSString *)stringAtAddress:(NSUInteger)address;

--- a/Source/CDMachOFile.m
+++ b/Source/CDMachOFile.m
@@ -279,6 +279,19 @@ static NSString *CDMachOFileMagicNumberDescription(uint32_t magic)
 
 #pragma mark -
 
+- (CDLCSegment *)dataConstSegment
+{
+    // macho objects from iOS 9 appear to store various sections
+    // in __DATA_CONST that were previously found in __DATA
+    CDLCSegment *seg = [self segmentWithName:@"__DATA_CONST"];
+
+    // Fall back on __DATA if it is not found for earlier behavior
+    if (!seg) {
+        seg = [self segmentWithName:@"__DATA"];
+    }
+    return seg;
+}
+
 - (CDLCSegment *)segmentWithName:(NSString *)segmentName;
 {
     for (id loadCommand in _loadCommands) {
@@ -558,7 +571,7 @@ static NSString *CDMachOFileMagicNumberDescription(uint32_t magic)
     // 0xced: @gparker I was hoping for a flag, but that will do it, thanks.
     // 0xced: @gparker Did you mean __DATA,__objc_imageinfo instead of __DATA,__objc_info ?
     // gparker: @0xced Yes, it's __DATA,__objc_imageinfo.
-    return [[self segmentWithName:@"__DATA"] sectionWithName:@"__objc_imageinfo"] != nil;
+    return [[self dataConstSegment] sectionWithName:@"__objc_imageinfo"] != nil;
 }
 
 - (Class)processorClass;

--- a/Source/CDObjectiveC2Processor.m
+++ b/Source/CDObjectiveC2Processor.m
@@ -27,7 +27,7 @@
 
 - (void)loadProtocols;
 {
-    CDSection *section = [[self.machOFile segmentWithName:@"__DATA"] sectionWithName:@"__objc_protolist"];
+    CDSection *section = [[self.machOFile dataConstSegment] sectionWithName:@"__objc_protolist"];
     
     CDMachOFileDataCursor *cursor = [[CDMachOFileDataCursor alloc] initWithSection:section];
     while ([cursor isAtEnd] == NO)
@@ -36,7 +36,7 @@
 
 - (void)loadClasses;
 {
-    CDSection *section = [[self.machOFile segmentWithName:@"__DATA"] sectionWithName:@"__objc_classlist"];
+    CDSection *section = [[self.machOFile dataConstSegment] sectionWithName:@"__objc_classlist"];
     
     CDMachOFileDataCursor *cursor = [[CDMachOFileDataCursor alloc] initWithSection:section];
     while ([cursor isAtEnd] == NO) {
@@ -50,7 +50,7 @@
 
 - (void)loadCategories;
 {
-    CDSection *section = [[self.machOFile segmentWithName:@"__DATA"] sectionWithName:@"__objc_catlist"];
+    CDSection *section = [[self.machOFile dataConstSegment] sectionWithName:@"__objc_catlist"];
     
     CDMachOFileDataCursor *cursor = [[CDMachOFileDataCursor alloc] initWithSection:section];
     while ([cursor isAtEnd] == NO) {
@@ -490,7 +490,7 @@
 
 - (CDSection *)objcImageInfoSection;
 {
-    return [[self.machOFile segmentWithName:@"__DATA"] sectionWithName:@"__objc_imageinfo"];
+    return [[self.machOFile dataConstSegment] sectionWithName:@"__objc_imageinfo"];
 }
 
 @end


### PR DESCRIPTION
Apple has moved various _objc sections that used to be found in the __DATA segment to __DATA_CONST and __DATA_DIRTY, causing class-dump to fail. This patch aims to fix class-dump on these new binaries.