### PR TITLE
Fix READ heap-buffer-overflow errors reported by ASan.

### DIFF
--- a/Source/CDLCSegment.m
+++ b/Source/CDLCSegment.m
@@ -37,7 +37,8 @@ NSString *CDSegmentEncryptionTypeName(CDSegmentEncryptionType type)
         _segmentCommand.cmdsize = [cursor readInt32];
         
         _name = [cursor readStringOfLength:16 encoding:NSASCIIStringEncoding];
-        memcpy(_segmentCommand.segname, [_name UTF8String], sizeof(_segmentCommand.segname));
+        size_t nameLength = [_name lengthOfBytesUsingEncoding:NSUTF8StringEncoding];
+        memcpy(_segmentCommand.segname, [_name UTF8String], MIN(sizeof(_segmentCommand.segname), nameLength));
         _segmentCommand.vmaddr   = [cursor readPtr];
         _segmentCommand.vmsize   = [cursor readPtr];
         _segmentCommand.fileoff  = [cursor readPtr];

--- a/Source/CDSection.m
+++ b/Source/CDSection.m
@@ -23,9 +23,11 @@
         _segment = segment;
         
         _sectionName = [cursor readStringOfLength:16 encoding:NSASCIIStringEncoding];
-        memcpy(_section.sectname, [_sectionName UTF8String], sizeof(_section.sectname));
+        size_t sectionNameLength = [_sectionName lengthOfBytesUsingEncoding:NSUTF8StringEncoding];
+        memcpy(_section.sectname, [_sectionName UTF8String], MIN(sectionNameLength, sizeof(_section.sectname)));
+        size_t segmentNameLength = [_sectionName lengthOfBytesUsingEncoding:NSUTF8StringEncoding];
         _segmentName = [cursor readStringOfLength:16 encoding:NSASCIIStringEncoding];
-        memcpy(_section.segname, [_segmentName UTF8String], sizeof(_section.segname));
+        memcpy(_section.segname, [_segmentName UTF8String], MIN(segmentNameLength, sizeof(_section.segname)));
         _section.addr      = [cursor readPtr];
         _section.size      = [cursor readPtr];
         _section.offset    = [cursor readInt32];


### PR DESCRIPTION
When initializing fixed size structure fields from strings, the number
of bytes copied needs to be the minimum of the structure field and the
string byte count.

Fixes the following class of errors found when running a version of
class-dump build with ASan (Address Sanitizer):

==67822==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x6030000095a0 at pc 0x0001068b4d2d bp 0x7fff595270b0 sp 0x7fff59526860
READ of size 16 at 0x6030000095a0 thread T0
    #0 0x1068b4d2c in __asan_memcpy (libclang_rt.asan_osx_dynamic.dylib+0x40d2c)
    #1 0x106716ed4 in -[CDLCSegment initWithDataCursor:](class-dump+0x100040ed4)
    #2 0x10672d82b in +[CDLoadCommand loadCommandWithDataCursor:](class-dump+0x10005782b)
    ...
