### PR TITLE
Use 32-bit Objective-C data pointer for 32-bit Mach-O files.

### DIFF
--- a/Source/CDObjectiveC2Processor.m
+++ b/Source/CDObjectiveC2Processor.m
@@ -221,7 +221,11 @@
 
     uint64_t value        = [cursor readPtr];
     class.isSwiftClass    = (value & 0x1) != 0;
-    objc2Class.data       = value & ~7;
+    if ([self.machOFile uses64BitABI]) {
+      objc2Class.data = value & ~7;
+    } else {
+      objc2Class.data = value & ~3;
+    }
 
     objc2Class.reserved1  = [cursor readPtr];
     objc2Class.reserved2  = [cursor readPtr];


### PR DESCRIPTION
Class-dump sometimes fails to process 32-bit files because the data cursor unconditionally aligns its Objective-C data pointer to a 64-bit boundary.