### PR TITLE
Support small methods and selector indirection

### DIFF
--- a/Source/CDMachOFile.m
+++ b/Source/CDMachOFile.m
@@ -350,6 +350,13 @@ static NSString *CDMachOFileMagicNumberDescription(uint32_t magic)
     if (offset == 0)
         return nil;
 
+    // Support small methods referencing selector names in __objc_selrefs.
+    CDSection *section = [segment sectionContainingAddress:address];
+    if ([[section sectionName] isEqualToString:@"__objc_selrefs"]) {
+        const void * reference = [self.data bytes] + offset;
+        offset = ([self ptrSize] == 8) ? *((uint64_t *)reference) : *((uint32_t *)reference);
+    }
+
     ptr = (uint8_t *)[self.data bytes] + offset;
 
     return [[NSString alloc] initWithBytes:ptr length:strlen(ptr) encoding:NSASCIIStringEncoding];

--- a/Source/CDMachOFileDataCursor.h
+++ b/Source/CDMachOFileDataCursor.h
@@ -28,5 +28,6 @@
 
 // Read using the current byteOrder and ptrSize (from the machOFile)
 - (uint64_t)readPtr;
+- (uint64_t)readPtr:(bool)small;
 
 @end

--- a/Source/CDMachOFileDataCursor.m
+++ b/Source/CDMachOFileDataCursor.m
@@ -110,4 +110,15 @@
     return 0;
 }
 
+- (uint64_t)readPtr:(bool)small;
+{
+    // "small" pointers are signed 32-bit values
+    if (small) {
+        // The pointers are relative to the location in the image, so get the offset before reading the offset:
+        return [self offset] + [self readInt32];
+    } else {
+        return [self readPtr];
+    }
+}
+
 @end

--- a/Source/CDObjectiveC2Processor.h
+++ b/Source/CDObjectiveC2Processor.h
@@ -5,6 +5,10 @@
 
 #import "CDObjectiveCProcessor.h"
 
+#define METHOD_LIST_T_RESERVED_BITS 0x7FFF0003
+#define METHOD_LIST_T_SMALL_METHOD_FLAG 0x80000000
+#define METHOD_LIST_T_ENTSIZE_MASK (METHOD_LIST_T_RESERVED_BITS|METHOD_LIST_T_SMALL_METHOD_FLAG)
+
 @interface CDObjectiveC2Processor : CDObjectiveCProcessor
 
 @end

--- a/Source/CDObjectiveC2Processor.m
+++ b/Source/CDObjectiveC2Processor.m
@@ -398,17 +398,19 @@
         
         struct cd_objc2_list_header listHeader;
         
-        // See getEntsize() from http://www.opensource.apple.com/source/objc4/objc4-532.2/runtime/objc-runtime-new.h
-        listHeader.entsize = [cursor readInt32] & ~(uint32_t)3;
-        listHeader.count   = [cursor readInt32];
-        NSParameterAssert(listHeader.entsize == 3 * [self.machOFile ptrSize]);
-        
+        // See https://opensource.apple.com/source/objc4/objc4-787.1/runtime/objc-runtime-new.h
+        uint32_t value = [cursor readInt32];
+        listHeader.entsize = value & ~METHOD_LIST_T_ENTSIZE_MASK;
+        bool small = (value & METHOD_LIST_T_SMALL_METHOD_FLAG) != 0;
+        listHeader.count = [cursor readInt32];
+        NSParameterAssert(listHeader.entsize == 3 * (small ? sizeof(int32_t) : [self.machOFile ptrSize]));
+
         for (uint32_t index = 0; index < listHeader.count; index++) {
             struct cd_objc2_method objc2Method;
-            
-            objc2Method.name  = [cursor readPtr];
-            objc2Method.types = [cursor readPtr];
-            objc2Method.imp   = [cursor readPtr];
+
+            objc2Method.name  = [cursor readPtr:small];
+            objc2Method.types = [cursor readPtr:small];
+            objc2Method.imp   = [cursor readPtr:small];
             NSString *name    = [self.machOFile stringAtAddress:objc2Method.name];
             NSString *types   = [self.machOFile stringAtAddress:objc2Method.types];
             
@@ -417,7 +419,7 @@
                 types = [self.machOFile stringAtAddress:extendedMethodTypes];
             }
             
-            //NSLog(@"%3u: %016lx %016lx %016lx", index, objc2Method.name, objc2Method.types, objc2Method.imp);
+            //NSLog(@"%3u: %016llx %016llx %016llx", index, objc2Method.name, objc2Method.types, objc2Method.imp);
             //NSLog(@"name: %@", name);
             //NSLog(@"types: %@", types);
             


### PR DESCRIPTION
Most of the `entsize` field is reserved for flags, see the definition of `method_list_t` in https://opensource.apple.com/source/objc4/objc4-787.1/runtime/objc-runtime-new.h

If the methods are marked as "small methods", the pointers for name, type, and imp are signed 32-bit _relative_ addresses. The addresses are relative to the location where the addresses are stored in memory, which translates to being relative to the location in the binary image.

Some of the pointers point into `__objc_selrefs`, which appears to be an additional layer of indirection. I have not observed an `__objc_selrefs` section that was 32-bit aligned or in a 32-bit binary, but I have added a conditional in the case that it is encountered.

I tested this change on a library that used to cause the crash listed in issue #100, and it appears to work with these changes (after changing `PLATFORM_IOSMAC` to `PLATFORM_MACCATALYST` to be able to build with Xcode 12). This fix is merged from work I did on https://github.com/preemptive/PPiOS-Rename.